### PR TITLE
Allow using with newer versions of resque

### DIFF
--- a/resque-loner.gemspec
+++ b/resque-loner.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.has_rdoc    = false
   
   s.rubyforge_project         = "resque-loner"
-  s.add_dependency 'resque', '1.9.5'
+  s.add_dependency 'resque', "< 2.0.0"
   s.add_development_dependency "rspec"
  
   s.files        = Dir.glob("{lib}/**/*") + %w(README.markdown)


### PR DESCRIPTION
latest release resque gem is up to 1.10.0, building from git nets 1.11.0 and the changes are pretty benign thus far. Instead of chasing an exact version to track against, do you think it would be safe pinning to anything under 2.x?

Thanks!
