### PR TITLE
FIxing an error when deleting queues

### DIFF
--- a/lib/resque-loner/helpers.rb
+++ b/lib/resque-loner/helpers.rb
@@ -51,7 +51,8 @@ module Resque
         end
 
         def self.cleanup_loners(queue)
-          redis.del(*redis.keys("loners:queue:#{queue}:job:*"))
+          keys = redis.keys("loners:queue:#{queue}:job:*")
+          redis.del(*keys) unless keys.empty?
         end
 
       end

--- a/spec/loner_spec.rb
+++ b/spec/loner_spec.rb
@@ -135,6 +135,10 @@ describe "Resque" do
       Resque.enqueue(SomeUniqueJob, "foo")
       Resque.size(:other_queue).should == 1
     end
+    
+    it 'should not raise an error when deleting an already empty queue' do
+      expect { Resque.remove_queue(:other_queue) }.to_not raise_error
+    end
 
   end
 


### PR DESCRIPTION
Hey guys, my test codebase is clearing all the queues before each run. But I've noticed this error crops up. We end up calling redis.del(*[]) and that present an argument problem.

This just noops if there aren't any keys, and there's a test along with it.
