### PR TITLE
Updating tests and syncing with bundler defaults

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,8 @@ require 'rake/testtask'
 
 require 'resque/tasks'
 
+require 'bundler/gem_tasks'
+
 def command?(command)
   system("type #{command} > /dev/null 2>&1")
 end

--- a/resque-loner.gemspec
+++ b/resque-loner.gemspec
@@ -18,16 +18,19 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'resque', '~>1.0'
   {
-    'bundler'             => '~> 1.0.0',
-    'rake'                => '~> 0.8.7',
+    'rake'                => '> 0.8.7',
     'rack-test'           => '~> 0.5.7',
     'rspec'               => '~> 2.5.0',
+    'mock_redis'          => '~> 0.2.0',
+    'yajl-ruby'           => '~> 0.8.2'
   }.each do |lib, version|
     s.add_development_dependency lib, version
   end
 
-  s.files        = Dir.glob("{lib}/**/*") + %w(README.markdown)
-  s.require_path = 'lib'
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.require_paths = ["lib"]
 
   s.description = <<desc
 Makes sure that for special jobs, there can be only one job with the same workload in one queue.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,26 +3,12 @@ require 'bundler/setup'
 require 'rspec'
 
 require 'ruby-debug'
+require 'mock_redis'
 require 'resque'
 require 'resque-loner'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    if !system("which redis-server")
-      puts '', "** can't find `redis-server` in your path"
-      puts "** try running `sudo rake install`"
-      abort ''
-    end
-    puts "Starting redis for testing at localhost:9736..."
-    `redis-server #{File.dirname(File.expand_path(__FILE__))}/redis-test.conf`
-    puts  "redis-server #{File.dirname(File.expand_path(__FILE__))}/redis-test.conf"
-    Resque.redis = 'localhost:9736'
-  end
-  
-  config.after(:suite) do
-    pid = `ps -e -o pid,command | grep [r]edis-test`.split(" ")[0]
-    puts "Killing test redis server #{pid}..."
-    `rm -f #{File.dirname(File.expand_path(__FILE__))}/dump.rdb`
-    Process.kill("KILL", pid.to_i)
+    Resque.redis = MockRedis.new
   end
 end


### PR DESCRIPTION
I've updated the test setup so that it correctly runs again.

As I was adding dependencies, I updated the gemspec and Rakefile to match the new bundler defaults as seen with the `bundle gem <gemname>` command.

I also removed the dependency on an actual redis server in favor of MockRedis.
