### PR TITLE
Configurable TTL for lock keys

### DIFF
--- a/lib/resque-loner/unique_job.rb
+++ b/lib/resque-loner/unique_job.rb
@@ -33,6 +33,23 @@ module Resque
           digest = Digest::MD5.hexdigest encode(:class => job, :args => args)
           digest
         end
+
+        #
+        # The default ttl of a locking key is -1, i.e. forever.  If for some reason you only 
+        # want the lock to be in place after a certain amount of time, override this method
+        # in your job.  For example: 
+        #
+        # class FooJob
+        #   include Resque::Plugins::UniqueJob
+        #   def self.loner_ttl
+        #     40
+        #   end
+        # end
+        #
+        def loner_ttl
+          -1
+        end
+
       end # ClassMethods
 
 


### PR DESCRIPTION
Hey - 
Thanks a ton for this gem - it works very well and it is easy to understand and work with.  

I have a project where there is a job that is super-critical, run on minute-by-minute schedule, and cannot be run concurrently.  I ran into an issue where a job key disappeared but the locking key did not (an issue caused by something outside of resque-loner), thus preventing the job from being rescheduled.  I've made a patch that puts the locking key's TTL in a class method on the job (and included a test and comments).  This will allow me to say "for SuperCriticalJob, I want the lock to be in place for only 5 minutes."
I hope you find it useful.
Cheers,
Billy Reisinger
