### PR TITLE
Separating the map_args functionaliy from redis_key

### DIFF
--- a/lib/resque-loner/unique_job.rb
+++ b/lib/resque-loner/unique_job.rb
@@ -24,12 +24,17 @@ module Resque
           payload = decode(encode(payload)) # This is the cycle the data goes when being enqueued/dequeued
           job  = payload[:class] || payload['class']
           args = (payload[:args]  || payload['args'])
-          args.map! do |arg|
-            arg.is_a?(Hash) ? arg.sort : arg
-          end
+          args = map_args(args)
 
           digest = Digest::MD5.hexdigest(encode(class: job, args: args))
           digest
+        end
+ 
+        # Separate method for easy overriding
+        def map_args(args)
+          args.map do |arg|
+            arg.is_a?(Hash) ? arg.sort : arg
+          end
         end
 
         #


### PR DESCRIPTION
Separating the `map_args` functionality away from `redis_key` method in order to allow the user to easily redefine the hashed args.

For example, I have a job that accepts certain information about the original user:

``` ruby
def self.perform(approval_id, approver_id)
  ...
end
```

But I want the job to be unique only by the approval_id parameter.  The solution after my change would be to simply overwrite map_args:

``` ruby
def self.map_args(args)
  args[0]
end
```
