### PR TITLE
Ensure that the encode and decode are symmetric

### DIFF
--- a/lib/resque-ext/job.rb
+++ b/lib/resque-ext/job.rb
@@ -12,6 +12,10 @@ module Resque
     def self.create_with_loner(queue, klass, *args)
       return create_without_loner(queue, klass, *args) if Resque.inline?
       item = { class: klass.to_s, args: args }
+
+      # Ensure that the encode and decode are symmetric
+      item = MultiJson.decode(MultiJson.encode(item))
+
       return 'EXISTED' if Resque::Plugins::Loner::Helpers.loner_queued?(queue, item)
       # multi block returns array of keys
       create_return_value = false

--- a/lib/resque-loner/helpers.rb
+++ b/lib/resque-loner/helpers.rb
@@ -31,13 +31,13 @@ module Resque
         end
 
         def self.unique_job_queue_key(queue, item)
-          job_key = constantize(item[:class] || item['class']).redis_key(item)
+          job_key = constantize(item['class']).redis_key(item)
           "loners:queue:#{queue}:job:#{job_key}"
         end
 
         def self.item_is_a_unique_job?(item)
           begin
-            klass = constantize(item[:class] || item['class'])
+            klass = constantize(item['class'])
             klass.included_modules.include?(::Resque::Plugins::UniqueJob)
           rescue
             false # Resque testsuite also submits strings as job classes while Resque.enqueue'ing,
@@ -46,7 +46,7 @@ module Resque
 
         def self.item_ttl(item)
           begin
-            constantize(item[:class] || item['class']).loner_ttl
+            constantize(item['class']).loner_ttl
           rescue
             -1
           end
@@ -54,7 +54,7 @@ module Resque
 
         def self.loner_lock_after_execution_period(item)
           begin
-            constantize(item[:class] || item['class']).loner_lock_after_execution_period
+            constantize(item['class']).loner_lock_after_execution_period
           rescue
             0
           end

--- a/resque-loner.gemspec
+++ b/resque-loner.gemspec
@@ -27,12 +27,13 @@ Gem::Specification.new do |s|
     rack-test
     rake
     rspec
-    rubocop
     simplecov
     yajl-ruby
   ).each do |gemname|
     s.add_development_dependency gemname
   end
+
+  s.add_development_dependency 'rubocop', '=0.19.1'
 
   s.executables = `git ls-files -z -- bin/*`.split("\0").map do
     |f| File.basename(f)


### PR DESCRIPTION
It's difficult to build a non brittle `redis_key` function when
sometimes receives a hash of symbols and sometimes receives a
hash of strings (a decoded JSON from Redis).