### PR TITLE
Handle nil job args; make be_true/be_false specs pass under RSpec 3.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ end
 
 task default: [:rubocop, :spec]
 
-Rubocop::RakeTask.new
+(defined?(RuboCop) ? RuboCop : Rubocop)::RakeTask.new
 
 desc 'Run specs for resque-loner'
 RSpec::Core::RakeTask.new(:spec) do |t|

--- a/lib/resque-loner/unique_job.rb
+++ b/lib/resque-loner/unique_job.rb
@@ -23,7 +23,7 @@ module Resque
         def redis_key(payload)
           payload = decode(encode(payload)) # This is the cycle the data goes when being enqueued/dequeued
           job  = payload[:class] || payload['class']
-          args = (payload[:args]  || payload['args'])
+          args = payload[:args] || payload['args'] || []
           args.map! do |arg|
             arg.is_a?(Hash) ? arg.sort : arg
           end

--- a/spec/loner_spec.rb
+++ b/spec/loner_spec.rb
@@ -122,8 +122,8 @@ describe 'Resque' do
 
     it 'should report if a job is queued or not' do
       Resque.enqueue SomeUniqueJob, 'foo'
-      Resque.enqueued?(SomeUniqueJob, 'foo').should be_true
-      Resque.enqueued?(SomeUniqueJob, 'bar').should be_false
+      Resque.enqueued?(SomeUniqueJob, 'foo').should be true
+      Resque.enqueued?(SomeUniqueJob, 'bar').should be false
     end
 
     it 'should report if a job is in a special queue or not' do
@@ -131,11 +131,11 @@ describe 'Resque' do
       SomeUniqueJob.instance_variable_set(:@queue, :special_queue)
 
       Resque.enqueue SomeUniqueJob, 'foo'
-      Resque.enqueued_in?(:special_queue, SomeUniqueJob, 'foo').should be_true
+      Resque.enqueued_in?(:special_queue, SomeUniqueJob, 'foo').should be true
 
       SomeUniqueJob.instance_variable_set(:@queue, default_queue)
 
-      Resque.enqueued?(SomeUniqueJob, 'foo').should be_false
+      Resque.enqueued?(SomeUniqueJob, 'foo').should be false
     end
 
     it 'should not be able to report if a non-unique job was enqueued' do
@@ -158,7 +158,7 @@ describe 'Resque' do
 
     it 'should honor loner_ttl in the redis key' do
       Resque.enqueue UniqueJobWithTtl
-      Resque.enqueued?(UniqueJobWithTtl).should be_true
+      Resque.enqueued?(UniqueJobWithTtl).should be true
       k = Resque.redis.keys 'loners:queue:unique_with_ttl:job:*'
       k.length.should == 1
       Resque.redis.ttl(k[0]).should be_within(2).of(UniqueJobWithTtl.loner_ttl)
@@ -182,6 +182,11 @@ describe 'Resque' do
       k = Resque.redis.keys 'loners:queue:unique_with_loner_lock_after_execution_period:job:*'
       k.length.should == 1
       Resque.redis.ttl(k[0]).should be_within(2).of(UniqueJobWithLockAfterExecution.loner_lock_after_execution_period)
+    end
+
+    it 'should handle nil job args from Resque' do
+      expect { Resque::Plugins::Loner::UniqueJob.redis_key(class: 'Something', args: nil) }.
+          to_not raise_error
     end
   end
 end


### PR DESCRIPTION
To the author:
The reason for this PR is that in our test environment (CentOS), we're somehow getting nil for the job args but an empty Array in local (OS X) testing. We're using resque-scheduler v2.0.0, resque 1.25.2, and resque-loner 1.2.1.

Do you have any idea why/how this could be happening?

We figure this change will make the code more robust in any case, but we'd still like to understand what is happening. Without this change, we have to explicitly pass a dummy arg to our no-arg jobs, which obviously isn't very nice.

Thanks!