### PR TITLE
Support Ruby 1.8

### DIFF
--- a/lib/resque-ext/job.rb
+++ b/lib/resque-ext/job.rb
@@ -11,7 +11,7 @@ module Resque
     #
     def self.create_with_loner(queue, klass, *args)
       return create_without_loner(queue, klass, *args) if Resque.inline?
-      item = { class: klass.to_s, args: args }
+      item = { :class => klass.to_s, :args => args }
       return 'EXISTED' if Resque::Plugins::Loner::Helpers.loner_queued?(queue, item)
       # multi block returns array of keys
       create_return_value = false

--- a/lib/resque-ext/resque.rb
+++ b/lib/resque-ext/resque.rb
@@ -4,7 +4,7 @@ module Resque
   end
 
   def self.enqueued_in?(queue, klass, *args)
-    item = { class: klass.to_s, args: args }
+    item = { :class => klass.to_s, :args => args }
     return nil unless Resque::Plugins::Loner::Helpers.item_is_a_unique_job?(item)
     Resque::Plugins::Loner::Helpers.loner_queued?(queue, item)
   end

--- a/lib/resque-loner/unique_job.rb
+++ b/lib/resque-loner/unique_job.rb
@@ -28,7 +28,7 @@ module Resque
             arg.is_a?(Hash) ? arg.sort : arg
           end
 
-          digest = Digest::MD5.hexdigest(encode(class: job, args: args))
+          digest = Digest::MD5.hexdigest(encode(:class => job, :args => args))
           digest
         end
 


### PR DESCRIPTION
I totally get it if you're not interested in this patch - Ruby 1.8 is old, outdated, and a pain to support - however the only changes I needed to make were to switch to old style hash assignment syntax, so it would be great if you were to merge this.