### PR TITLE
rename redis_key to resque_loner_redis_key

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,7 +82,7 @@ Here's how these keys are constructed:
 
     resque:loners:queue:cache_sweeps:job:5ac5a005253450606aa9bc3b3d52ea5b
     |          |        |                |
-    |          |        |                `---- Job's ID (#redis_key method)
+    |          |        |                `---- Job's ID (#resque_loner_redis_key method)
     |          |        `--------------------- Name of the queue
     |          `------------------------------ Prefix for this plugin
     `----------------------------------------- Your redis namespace
@@ -91,15 +91,15 @@ The last part of this key is the job's ID, which is pretty much your queue item'
 
     { 'class': 'CacheSweeper', 'args': [1] }`
 
-The default method to create a job ID from these parameters  is to do some normalization on the payload and then md5'ing it (defined in `Resque::Plugins::UniqueJob#redis_key`).
+The default method to create a job ID from these parameters  is to do some normalization on the payload and then md5'ing it (defined in `Resque::Plugins::UniqueJob#resque_loner_redis_key`).
 
 You could also use the whole payload or anything else as a redis key, as long as you make sure these requirements are met:
 
-1. Two jobs of the same class with the same parameters/arguments/workload must produce the same redis_key
+1. Two jobs of the same class with the same parameters/arguments/workload must produce the same resque_loner_redis_key
 2. Two jobs with either a different class or different parameters/arguments/workloads must not produce the same redis key 
 3. The key must not be binary, because this restriction applies to redis keys: *Keys are not binary safe strings in Redis, but just strings not containing a space or a newline character. For instance "foo" or "123456789" or "foo_bar" are valid keys, while "hello world" or "hello\n" are not.* (see http://code.google.com/p/redis/wiki/IntroductionToRedisDataTypes)
 
-So when your job overwrites the #redis_key method, make sure these requirements are met. And all should be good.
+So when your job overwrites the #resque_loner_redis_key method, make sure these requirements are met. And all should be good.
 
 ### Resque integration
 

--- a/lib/resque-loner/helpers.rb
+++ b/lib/resque-loner/helpers.rb
@@ -31,7 +31,7 @@ module Resque
         end
 
         def self.unique_job_queue_key(queue, item)
-          job_key = constantize(item[:class] || item['class']).redis_key(item)
+          job_key = constantize(item[:class] || item['class']).resque_loner_redis_key(item)
           "loners:queue:#{queue}:job:#{job_key}"
         end
 

--- a/lib/resque-loner/unique_job.rb
+++ b/lib/resque-loner/unique_job.rb
@@ -3,7 +3,7 @@ require 'resque-loner/helpers'
 
 #
 #  If you want your job to be unique, include this module in it. If you wish,
-#  you can overwrite this implementation of redis_key to fit your needs
+#  you can overwrite this implementation of resque_loner_redis_key to fit your needs
 #
 module Resque
   module Plugins
@@ -20,7 +20,7 @@ module Resque
         #  Payload is what Resque stored for this job along with the job's class name.
         #  On a Resque with no plugins installed, this is a hash containing :class and :args
         #
-        def redis_key(payload)
+        def resque_loner_redis_key(payload)
           payload = decode(encode(payload)) # This is the cycle the data goes when being enqueued/dequeued
           job  = payload[:class] || payload['class']
           args = (payload[:args]  || payload['args'])


### PR DESCRIPTION
I just had a fun time debugging a weird behavior when using both resque-restriction and resque-loner in the same job. It turned out both plugins use and provide an implementation for a `redis_key` method, but due to the nature of each plugin, the implementations are not compatible. resque-restriction needs the key to identify a **group** of jobs, whereas resque-loner needs the key to identify a **single** job

I think it would be nice if each plugin uses a name that's more specific to itself. What do you think?

This PR is not addressing backward compatibility. If you like the idea maybe we can discuss more. One way is to only release this in a major version upgrade